### PR TITLE
Overlay bitmaps

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -46,6 +46,7 @@ find_library( # Sets the name of the path variable.
 # build script, prebuilt third-party libraries, or system libraries.
 target_link_libraries( # Specifies the target library.
         pinenote
+        jnigraphics
 
         # Links the target library to the log library
         # included in the NDK.

--- a/app/src/main/cpp/pinenote_jni.cpp
+++ b/app/src/main/cpp/pinenote_jni.cpp
@@ -141,7 +141,10 @@ Java_net_mulliken_pinenotenotebook_NoteView_nativeGetFullOverlayBitmap(JNIEnv *e
     int _width = pineNotePen->ebc_info.width;
     int _height = pineNotePen->ebc_info.height;
 
-    return createBitmapFromPixelData(env, _width, _height, pixelData);
+    jobject bitmap = createBitmapFromPixelData(env, _width, _height, pixelData);
+    free(pixelData);
+
+    return bitmap;
 }
 
 extern "C"
@@ -152,5 +155,8 @@ Java_net_mulliken_pinenotenotebook_NoteView_nativeGetOverlayBitmap(JNIEnv *env, 
     int _width = pineNotePen->display_y2 - pineNotePen->display_y1;
     int _height = pineNotePen->display_x2 - pineNotePen->display_x1;
 
-    return createBitmapFromPixelData(env, _width, _height, pixelData);
+    jobject bitmap = createBitmapFromPixelData(env, _width, _height, pixelData);
+    free(pixelData);
+
+    return bitmap;
 }

--- a/app/src/main/cpp/pinenote_jni.cpp
+++ b/app/src/main/cpp/pinenote_jni.cpp
@@ -148,7 +148,7 @@ extern "C"
 JNIEXPORT jobject JNICALL
 Java_net_mulliken_pinenotenotebook_NoteView_nativeGetOverlayBitmap(JNIEnv *env, jobject obj)
 {
-    uint32_t *pixelData = pineNotePen->getFullPixelData();
+    uint32_t *pixelData = pineNotePen->getBoundedPixelData();
     int _width = pineNotePen->display_y2 - pineNotePen->display_y1;
     int _height = pineNotePen->display_x2 - pineNotePen->display_x1;
 

--- a/app/src/main/cpp/pinenote_jni.cpp
+++ b/app/src/main/cpp/pinenote_jni.cpp
@@ -112,14 +112,7 @@ Java_net_mulliken_pinenotenotebook_NoteView_nativeOnWindowFocusChanged(JNIEnv *e
     }
 }
 
-extern "C"
-JNIEXPORT jobject JNICALL
-Java_net_mulliken_pinenotenotebook_NoteView_nativeGetFullOverlayBitmap(JNIEnv *env, jobject obj)
-{
-    uint32_t *pixelBuffer = pineNotePen->getPixelData();
-    int _width = pineNotePen->ebc_info.width;
-    int _height = pineNotePen->ebc_info.height;
-
+jobject createBitmapFromPixelData(JNIEnv *env, int _width, int _height, const uint32_t* pixelData) {
     jclass bitmapConfig = env->FindClass("android/graphics/Bitmap$Config");
     jfieldID rgba8888FieldID = env->GetStaticFieldID(bitmapConfig, "ARGB_8888", "Landroid/graphics/Bitmap$Config;");
     jobject rgba8888Obj = env->GetStaticObjectField(bitmapConfig, rgba8888FieldID);
@@ -131,11 +124,33 @@ Java_net_mulliken_pinenotenotebook_NoteView_nativeGetFullOverlayBitmap(JNIEnv *e
     jintArray pixels = env->NewIntArray(_width * _height);
     for (int i = 0; i < _width * _height; i++)
     {
-        int currentPixel = pixelBuffer[i];
+        int currentPixel = pixelData[i];
         env->SetIntArrayRegion(pixels, i, 1, &currentPixel);
     }
 
     jmethodID setPixelsMid = env->GetMethodID(bitmapClass, "setPixels", "([IIIIIII)V");
     env->CallVoidMethod(bitmapObj, setPixelsMid, pixels, 0, _width, 0, 0, _width, _height);
     return bitmapObj;
+}
+
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_net_mulliken_pinenotenotebook_NoteView_nativeGetFullOverlayBitmap(JNIEnv *env, jobject obj)
+{
+    uint32_t *pixelData = pineNotePen->getFullPixelData();
+    int _width = pineNotePen->ebc_info.width;
+    int _height = pineNotePen->ebc_info.height;
+
+    return createBitmapFromPixelData(env, _width, _height, pixelData);
+}
+
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_net_mulliken_pinenotenotebook_NoteView_nativeGetOverlayBitmap(JNIEnv *env, jobject obj)
+{
+    uint32_t *pixelData = pineNotePen->getFullPixelData();
+    int _width = pineNotePen->display_y2 - pineNotePen->display_y1;
+    int _height = pineNotePen->display_x2 - pineNotePen->display_x1;
+
+    return createBitmapFromPixelData(env, _width, _height, pixelData);
 }

--- a/app/src/main/cpp/pinenotelib.cpp
+++ b/app/src/main/cpp/pinenotelib.cpp
@@ -94,6 +94,51 @@ void PineNoteLib::dumpToBitmap(const char * filename) const {
     image.write(filename);
 }
 
+
+uint32_t* PineNoteLib::getPixelData() const {
+    auto *pixelBuffer = (uint32_t*) malloc(ebc_info.width * ebc_info.height * sizeof(uint32_t));
+
+    for (int y = 0; y < ebc_info.height; y++) {
+        for (int x = 0; x < ebc_info.width; x++) {
+            unsigned int offset = y * ebc_info.width + x;
+            float gray_4bit;
+
+            if (offset % 2 == 1) { // right pixel (most 4 significant bits)
+                unsigned int osd_offset = offset - 1;
+                osd_offset /= 2;
+
+                // Zero the first 4 bits to get pixel value
+                gray_4bit = (float) (osd_buffer_base[osd_offset] & 0x0f);
+            } else { // left pixel (least 4 significant bits)
+                unsigned int osd_offset = offset / 2;
+
+                // Zero the last 4 bits and shift right 4 to get pixel value
+                gray_4bit = (float) ((osd_buffer_base[osd_offset] & 0xf0) >> 4);
+            }
+
+            // If pixel is white, set to transparent and skip pixel creation
+            if (gray_4bit == 0x0f) {
+                pixelBuffer[offset] = 0;
+                continue;
+            }
+
+            // Divide by 15 to get relative grey value, multiply by 255 to scale to 8 bits
+            auto gray_8bit = (uint32_t) ((gray_4bit / 15) * 255);
+
+            // Create A, R, G, B with channel data at the respective byte offset
+            uint32_t a = UINT32_MAX << 24;
+            uint32_t b = gray_8bit << 16;
+            uint32_t g = gray_8bit << 8;
+            uint32_t r = gray_8bit;
+
+            // Set pixel
+            pixelBuffer[offset] = a | b | g | r;
+        }
+    }
+
+    return pixelBuffer;
+}
+
 void PineNoteLib::setDrawArea(int x1, int y1, int x2, int y2) {
     // TODO: Set the draw area
 

--- a/app/src/main/cpp/pinenotelib.h
+++ b/app/src/main/cpp/pinenotelib.h
@@ -65,7 +65,13 @@ public:
 
     void drawShape(Shape& shape, unsigned int color) const;
 
-    uint32_t *getPixelData() const;
+    uint32_t *getFullPixelData() const;
+
+    // The area of the screen that is being drawn to
+    int display_x1{};
+    int display_y1{};
+    int display_x2{};
+    int display_y2{};
 
 private:
     static PineNoteLib *instance;
@@ -76,15 +82,12 @@ private:
 
     void clearOsdBuffer() const;
 
-    // The area of the screen that is being drawn to
-    int display_x1{};
-    int display_y1{};
-    int display_x2{};
-    int display_y2{};
-
     // pointer to where the EBC is mapped in memory
     uint8_t *ebc_base = nullptr;
 
+    uint32_t *getBoundedPixelData() const;
+
+    uint32_t getArgbPixelAt(unsigned int offset, int x, int y) const;
 };
 
 #endif // PINENOTELIB_H

--- a/app/src/main/cpp/pinenotelib.h
+++ b/app/src/main/cpp/pinenotelib.h
@@ -65,6 +65,8 @@ public:
 
     void drawShape(Shape& shape, unsigned int color) const;
 
+    uint32_t *getPixelData() const;
+
 private:
     static PineNoteLib *instance;
 
@@ -82,6 +84,7 @@ private:
 
     // pointer to where the EBC is mapped in memory
     uint8_t *ebc_base = nullptr;
+
 };
 
 #endif // PINENOTELIB_H

--- a/app/src/main/cpp/pinenotelib.h
+++ b/app/src/main/cpp/pinenotelib.h
@@ -73,6 +73,8 @@ public:
     int display_x2{};
     int display_y2{};
 
+    uint32_t *getBoundedPixelData() const;
+
 private:
     static PineNoteLib *instance;
 
@@ -84,8 +86,6 @@ private:
 
     // pointer to where the EBC is mapped in memory
     uint8_t *ebc_base = nullptr;
-
-    uint32_t *getBoundedPixelData() const;
 
     uint32_t getArgbPixelAt(unsigned int offset, int x, int y) const;
 };

--- a/app/src/main/java/net/mulliken/pinenotenotebook/NoteJNI.java
+++ b/app/src/main/java/net/mulliken/pinenotenotebook/NoteJNI.java
@@ -39,6 +39,8 @@ public class NoteJNI {
 
     private native Bitmap nativeGetFullOverlayBitmap();
 
+    private native Bitmap nativeGetOverlayBitmap();
+
     private static NoteJNI instance;
 
     public static NoteJNI getInstance() {

--- a/app/src/main/java/net/mulliken/pinenotenotebook/NoteJNI.java
+++ b/app/src/main/java/net/mulliken/pinenotenotebook/NoteJNI.java
@@ -1,6 +1,7 @@
 package net.mulliken.pinenotenotebook;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.util.Log;
 import android.view.MotionEvent;
 
@@ -35,6 +36,8 @@ public class NoteJNI {
     private native void nativeSetDisplayMode(int mode);
 
     private native void nativeClearOverlay();
+
+    private native Bitmap nativeGetFullOverlayBitmap();
 
     private static NoteJNI instance;
 

--- a/app/src/main/java/net/mulliken/pinenotenotebook/NoteView.java
+++ b/app/src/main/java/net/mulliken/pinenotenotebook/NoteView.java
@@ -1,6 +1,7 @@
 package net.mulliken.pinenotenotebook;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -23,6 +24,7 @@ public class NoteView extends View {
     private native void nativeOnDetachedFromWindow();
     private native void nativeOnSizeChanged(int left, int top, int right, int bottom);
     private native void nativeOnWindowFocusChanged(boolean hasFocus);
+    private native Bitmap nativeGetFullOverlayBitmap();
 
     public NoteView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -86,5 +88,9 @@ public class NoteView extends View {
         super.onDraw(canvas);
 
         // TODO: draw the note
+    }
+
+    public Bitmap getFullOverlayBitmap() {
+        return nativeGetFullOverlayBitmap();
     }
 }

--- a/app/src/main/java/net/mulliken/pinenotenotebook/NoteView.java
+++ b/app/src/main/java/net/mulliken/pinenotenotebook/NoteView.java
@@ -25,6 +25,7 @@ public class NoteView extends View {
     private native void nativeOnSizeChanged(int left, int top, int right, int bottom);
     private native void nativeOnWindowFocusChanged(boolean hasFocus);
     private native Bitmap nativeGetFullOverlayBitmap();
+    private native Bitmap nativeGetOverlayBitmap();
 
     public NoteView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -92,5 +93,9 @@ public class NoteView extends View {
 
     public Bitmap getFullOverlayBitmap() {
         return nativeGetFullOverlayBitmap();
+    }
+
+    public Bitmap getOverlayBitmap() {
+        return nativeGetOverlayBitmap();
     }
 }


### PR DESCRIPTION
This PR adds two functions to NoteView. `getFullOverlayBitmap` converts the osd_buffer_base to an ARGB_8888 bitmap and returns the bitmap object. `getOverlayBitmap` does the same, but creates a bitmap the size of the NoteView and only converts pixels within the bounds set by `nativeOnSizeChanged`